### PR TITLE
📄 Fix 蓝奏云 (demo)

### DIFF
--- a/index.md
+++ b/index.md
@@ -48,7 +48,7 @@ Wolfram Engine 的激活方法可参考官网的介绍 [How do I set up the Wolf
 
 * (12.0.0) Linux
   * [百度网盘](https://pan.baidu.com/s/1qX5Z36w3SoSFCEsGSGqP9g) 提取码：`rw3a`
-  * [蓝奏云（分卷）](https://www.lanzous.com/b00n4te9a/) 密码：`dn3c`
+  * [蓝奏云（分卷）](https://ww.lanzous.com/b00n4te9a/) 密码：`dn3c` （如果打不开，请把域名 `ww.lanzous.com` 中的 `ww` 随便换成其他字母。）
   * [SharePoint](https://hii9w-my.sharepoint.com/:u:/g/personal/richard_liu_233455_xyz/EVPw9cN-UltGgGotCAOYVLYBjZdluPfngX5y96JpvyO8zA?e=NlPwuc)
 
 > **注意**


### PR DESCRIPTION
## 摘要

***This is a demonstration.***

蓝奏云可能遭到了 DNS 污染。按官方的说法，部分地区运营商下无法访问，需要分享者设置个性化域名（`xxx.lanzous.com` 的格式）。其实，只要**访客**在 `xxx` 部分随便输个不是 `www` 的玩意就能接通（泛解析）。